### PR TITLE
Configure for remote build: update .funcignore and azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -23,6 +23,7 @@ services:
     project: ./packages/api
     language: ts
     host: function
+    remoteBuild: true
 
 hooks:
   postprovision:

--- a/packages/api/.funcignore
+++ b/packages/api/.funcignore
@@ -1,13 +1,12 @@
 *.js.map
-*.ts
 .git*
 .vscode
 __azurite_db*__.json
 __blobstorage__
 __queuestorage__
+node_modules/
 local.settings.json
 test
-tsconfig.json
 .faiss
 api.http
 .env.sample


### PR DESCRIPTION
## Summary

Fixes the project configuration for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `api` service
- **packages/api/.funcignore**: Reconfigured for remote build — removed `*.ts` and `tsconfig.json` from ignore list, added `node_modules`

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. The previous `.funcignore` was configured for local build: it ignored `*.ts` and `tsconfig.json` (preventing remote compilation) and did not ignore `node_modules` (uploading all dependencies). This change flips the configuration so source files are included and `node_modules` are excluded, allowing remote build to compile TypeScript and install dependencies correctly.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.